### PR TITLE
increase BootDevice description length from 60 to 80

### DIFF
--- a/src/boot.c
+++ b/src/boot.c
@@ -482,7 +482,7 @@ interactive_bootmenu(void)
     int maxmenu = 0;
     struct bootentry_s *pos;
     hlist_for_each_entry(pos, &BootList, node) {
-        char desc[60];
+        char desc[80];
         maxmenu++;
         printf("%d. %s\n", maxmenu
                , strtcpy(desc, pos->description, ARRAY_SIZE(desc)));


### PR DESCRIPTION
on my GANDOF ChromeBook it's cut off and only shows
> 1. AHCI/O: KINGSTON SNS4151S316GD ATA-10 Hard-Disk (15272 MiBy

Note: all the other 'char desc' in the boot.c are set to 256.